### PR TITLE
Swipe right edge to close menu drawer.

### DIFF
--- a/EdgeSwipeSample/EdgeSwipeSample.iOS/Renderers/MyPhoneMasterDetailRenderer.cs
+++ b/EdgeSwipeSample/EdgeSwipeSample.iOS/Renderers/MyPhoneMasterDetailRenderer.cs
@@ -38,19 +38,23 @@ namespace EdgeSwipeSample.iOS.Renderers
             base.ViewDidLoad();
 
             // Attach the Edge Gesture.
-            var interactiveTransitionRecognizer = new UIScreenEdgePanGestureRecognizer();
-            interactiveTransitionRecognizer.AddTarget(() =>
-                InteractiveTransitionRecognizerAction(interactiveTransitionRecognizer));
-            interactiveTransitionRecognizer.Edges = UIRectEdge.Left;
-            View.AddGestureRecognizer(interactiveTransitionRecognizer);
+            var edgeSwipeOpenRecognizer = new UIScreenEdgePanGestureRecognizer();
+            edgeSwipeOpenRecognizer.AddTarget(() => InteractiveTransitionRecognizerAction(edgeSwipeOpenRecognizer, true));
+            edgeSwipeOpenRecognizer.Edges = UIRectEdge.Left;
+            View.AddGestureRecognizer(edgeSwipeOpenRecognizer);
+
+            var edgeSwipeCloseRecognizer = new UIScreenEdgePanGestureRecognizer();
+            edgeSwipeCloseRecognizer.AddTarget(() => InteractiveTransitionRecognizerAction(edgeSwipeCloseRecognizer, false));
+            edgeSwipeCloseRecognizer.Edges = UIRectEdge.Right;
+            View.AddGestureRecognizer(edgeSwipeCloseRecognizer);
         }
 
-        void InteractiveTransitionRecognizerAction(UIScreenEdgePanGestureRecognizer sender)
+        void InteractiveTransitionRecognizerAction(UIScreenEdgePanGestureRecognizer sender, bool presentedValue)
         {
             // If we get swipe from the left edge, we show the menu.
 
             if (sender.State == UIGestureRecognizerState.Began)
-                SetPresentedValue(true);
+                SetPresentedValue(presentedValue);
         }
 
 


### PR DESCRIPTION
Thanks for this repo!
It's exactly what I needed. I have a page that allows users to draw their signature and it was conflicting with the menu drawer gesture.
Your custom renderer solved the issue.
I've just added support for closing the drawer by swiping the right edge of the screen.